### PR TITLE
⚒🛠💣 [Bug Fix] (config + script) Fix the issue about 'git diff' of '.github/release-notes.md' and command lines of GitHub Action configuration.

### DIFF
--- a/.github/workflows/build_git-tag_and_create_github-release.yaml
+++ b/.github/workflows/build_git-tag_and_create_github-release.yaml
@@ -93,7 +93,7 @@ jobs:
           release=$(bash ./scripts/ci/build_git-tag_or_create_github-release.sh ${{ inputs.project_type }} ${{ inputs.debug_mode }})
           echo "📄 Release log: $release"
 
-          release_version=$(echo "$release" | grep -E "\[GitHub Action - Reusable workflow\] \[Final Running Result\] (Official\-Release and version: ([0-9]{1,})|(Pre\-Release))" | grep -E -o "([0-9]{1,})")
+          release_version=$(echo "$release" | grep -E "\[GitHub Action - Reusable workflow\] \[Final Running Result\] (Official\-Release and version: ([0-9]{1,})|(Pre\-Release))" | grep -E -o "(([0-9]{1,})|(Pre\-Release))")
           echo "🤖 Release Version: $release_version"
 
           echo "::set-output name=release_version::$(echo $release_version)"

--- a/.github/workflows/build_git-tag_and_create_github-release.yaml
+++ b/.github/workflows/build_git-tag_and_create_github-release.yaml
@@ -93,7 +93,7 @@ jobs:
           release=$(bash ./scripts/ci/build_git-tag_or_create_github-release.sh ${{ inputs.project_type }} ${{ inputs.debug_mode }})
           echo "📄 Release log: $release"
 
-          release_version=$(echo "$release" | grep -E "\[GitHub Action - Reusable workflow\] \[Final Running Result\] Official-Release and version: ([0-9]{1,})" | grep -E -o "([0-9]{1,})")
+          release_version=$(echo "$release" | grep -E "\[GitHub Action - Reusable workflow\] \[Final Running Result\] (Official\-Release and version: ([0-9]{1,})|(Pre\-Release))" | grep -E -o "([0-9]{1,})")
           echo "🤖 Release Version: $release_version"
 
           echo "::set-output name=release_version::$(echo $release_version)"

--- a/scripts/ci/build_git-tag_or_create_github-release.sh
+++ b/scripts/ci/build_git-tag_or_create_github-release.sh
@@ -294,7 +294,16 @@ elif [ "$Input_Arg_Release_Type" == 'github-action-reusable-workflow' ]; then
     git remote -v
 
     echo "🔬 📄 🌳 ⛓ 🌳 Check the different of '.github/release-notes.md' between current git branch and master branch ..."
-    release_notes_has_diff=$(git diff origin/master "$Current_Branch" -- .github/release-notes.md | cat)
+    # # v1: compare by git branches
+#    release_notes_has_diff=$(git diff origin/master "$Current_Branch" -- .github/release-notes.md | cat)
+    # # v2: compare by git tag
+    all_git_tags=$(git tag -l | cat)
+    declare -a all_git_tags_array=( $(echo "$all_git_tags" | awk -v RS='' '{gsub("\n","  "); print}') )
+    all_git_tags_array_len=${#all_git_tags_array[@]}
+    latest_git_tag=${all_git_tags_array[$all_git_tags_array_len - 1]}
+    echo "🔎 🌳 🏷 The latest git tag: $latest_git_tag"
+
+    release_notes_has_diff=$(git diff "$latest_git_tag" "$Current_Branch" -- .github/release-notes.md | cat)
     echo "🔎 🔬 📄 different of '.github/release-notes.md': $release_notes_has_diff"
 
     if [ "$release_notes_has_diff" != "" ]; then

--- a/scripts/ci/build_git-tag_or_create_github-release.sh
+++ b/scripts/ci/build_git-tag_or_create_github-release.sh
@@ -131,6 +131,9 @@ git_global_user_email=$(git config --global user.email)
 echo "🔎 🌳  Current git name: $git_global_username"
 echo "🔎 🌳  Current git email: $git_global_user_email"
 
+git pull
+echo "📩 🌳  git pull done"
+
 declare Tag_Version    # This is the return value of function 'get_latest_version_by_git_tag'
 get_latest_version_by_git_tag() {
     # # # # The types to get version by tag: 'git' or 'github'


### PR DESCRIPTION
#### Pre-Checking

‼️Please must read this section and check by yourself.
⚠️Do NOT modify this section if it doesn't have any necessary reason.

Please verify the PR header should be satisfied below format: 
    
    [commit topic] (commit scope) <commit summary>

* commit topic: The major topic of your modify. It could have multiple topics, e.g., [Breaking Change + Test].
* commit scope: The scope in project of modify. It could have multiple scopes, e.g., (config + test).
* commit summary: Summary of the commits. It should be clear that the target, the KEY POINT why you modify it or what you resolve, etc.

Please refer to [GCR (Git Commit Rules)](../../.gitcommitrules) to get more detail about it.

<hr>

### _Target_

* Fix the issues about **CI/CD**:
    * Logic problem of '_git diff_' of file _.github/release-notes.md_.
    * Logic problem of command line in configuration of GitHub Action about searching key words in log message to verify whether it's official-release or pre-release.


### _Modify Code Scope_

* About **_shell script_**:
    * scripts/ci/build_git-tag_or_create_github-release.sh

* About configuration of **_GitHub Action_**:
    * .github/workflows/build_git-tag_and_create_github-release.yaml


### _Effecting Scope_

* The all automations after developers pushes their commits to GitHub platform.
    * The CI automation job about building git tag or creating GitHub release.


### _Description_

* Add some processes in **shell script**:
    * _git pull_ to get the tag info.
    * _git tag_ to get which tag we should use to compare.

* Modify the command line in configuration of **GitHub Action**:
    * Modify the command line about filtering to get the final release type (official-release or pre-release). 
