### PR TITLE
🔬🧪🧬 [Refactor] (config) Upgrade the GitHub Action syntax usage about set-output commands.

### DIFF
--- a/.github/workflows/prepare_test_items.yaml
+++ b/.github/workflows/prepare_test_items.yaml
@@ -43,5 +43,5 @@ jobs:
       - id: set-matrix
         run: |
           sudo apt-get install jq
-          echo "::set-output name=all_test_items::$(bash ${{ inputs.shell_path }} ${{ inputs.shell_arg }})"
+          echo "all_test_items=$(bash ${{ inputs.shell_path }} ${{ inputs.shell_arg }})" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
### _Target_

* Upgrade the GitHub Action syntax usage about set-output commands.
* Refer: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


### _Modify Code Scope_

* The configurations in directory _.github/workflow_.


### _Effecting Scope_

* Nothing, just upgrade the syntax usage in configuration.


### _Description_

* Change to use environment variable _GITHUB_OUTPUT_.
