### PR TITLE
🔬🧪🧬 [Refactor] (config) Upgrade GitHub Action syntax usage and actions version.

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,17 +1,42 @@
-### 🎉🎊🍾 New feature
-<hr>
+[//]: # (### 🎉🎊🍾 New feature)
 
-1. Add new options about set up and run a sample HTTP server for testing if it needs in some testing scenario (_run_test_items_via_pytest.yaml_).
+[//]: # (<hr>)
 
+[//]: # ()
+[//]: # (1. Add new options about set up and run a sample HTTP server for testing if it needs in some testing scenario &#40;_run_test_items_via_pytest.yaml_&#41;.)
+
+[//]: # ()
 ### 🛠⚙️🔩 **Breaking Change**
 <hr>
 
-1. Integrate the feature about organizing and generating testing coverage reports into a reusable workflow. So workflow could be shorter and clear (_organize_and_generate_test_cov_reports.yaml_).
-2. Integrate all the uploading test coverage report features into a reusable workflow (_upload_test_cov_report.yaml_).
-3. Update document README.
-4. Move the PR template to **_.github_** directory (for working finely).
+1. Clear the under testing environments or settings to reduce resource.
 
-### ⚒⚒💣 **Bug Fix** 
+    1-1. Deprecate and remove some runtime OS versions.
+
+    * Deprecated settings: _ubuntu-18.04_, _ubuntu-20.04_, _ubuntu-22.04_, _macos-10.15_, _macos-11_, _macos-12_
+    * New settings: _ubuntu-latest_, _macos-latest_
+
+    1-2. Add more Python version for testing
+
+    * New version: _Python 3.11_
+
+[//]: # (### ⚒⚒💣 **Bug Fix** )
+
+[//]: # (<hr>)
+
+[//]: # ()
+[//]: # (1. Fix the issue about uploading test coverage report cannot work at all.)
+
+### 🔬🧪🧬 **Refactor**
 <hr>
 
-1. Fix the issue about uploading test coverage report cannot work at all.
+1. Upgrade the GitHub Action syntax usage about set-output commands.
+
+    * Change to use environment variable _GITHUB_OUTPUT_.
+    * Refer: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
+
+2. Upgrade the actions which depends on Node.JS version 12 to newer version.
+
+    * Upgrade _actions/checkout_ to version 3.
+    * Upgrade _actions/setup-python_ to version 4.
+    * Refer: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

--- a/.github/release-title.md
+++ b/.github/release-title.md
@@ -1,1 +1,1 @@
-v2.0.0 - More short and clear <0001f9f9>🍻
+v3.0.0 - Modify under testing OS & Python versions and upgrade dependencies actions 🍻

--- a/.github/workflows/build_git-tag_and_create_github-release.yaml
+++ b/.github/workflows/build_git-tag_and_create_github-release.yaml
@@ -72,7 +72,7 @@ jobs:
       matrix_github_action_reusable_workflow: ${{ steps.github_action_reusable_workflow_release.outputs.release_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download shell script for checking input parameters
         run: curl https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Workflow-Template-Python/develop/scripts/ci/build_git-tag_or_create_github-release.sh --output ./scripts/ci/build_git-tag_or_create_github-release.sh

--- a/.github/workflows/build_git-tag_and_create_github-release.yaml
+++ b/.github/workflows/build_git-tag_and_create_github-release.yaml
@@ -88,7 +88,7 @@ jobs:
           release_type=$(echo "$release" | grep -E "\[Python\] \[Final Running Result\] ((Official\-Release)|(Pre\-Release))" | grep -E -o "((Official\-Release)|(Pre\-Release))")
           echo "🐍 Release Type: $release_type"
 
-          echo "::set-output name=release_type::$(echo $release_type)"
+          echo "release_type=$(echo $release_type)" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.github_auth_token }}
 
@@ -103,7 +103,7 @@ jobs:
           release_version=$(echo "$release" | grep -E "\[GitHub Action - Reusable workflow\] \[Final Running Result\] (Official\-Release and version: ([0-9]{1,})|(Pre\-Release))" | grep -E -o "(([0-9]{1,})|(Pre\-Release))")
           echo "🤖 Release Version: $release_version"
 
-          echo "::set-output name=release_version::$(echo $release_version)"
+          echo "release_version=$(echo $release_version)" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.github_auth_token }}
 

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -45,7 +45,7 @@ jobs:
       RELEASE_TYPE: ${{ needs.test_build_git-tag_and_create_github-release.outputs.github-action_reusable_workflow_release_version }}
       DEBUG_MODE: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Check it whether get the output of previous one job which has version info or not
         run: bash scripts/ci/check_getting_output.sh

--- a/.github/workflows/organize_and_generate_test_cov_reports.yaml
+++ b/.github/workflows/organize_and_generate_test_cov_reports.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download code coverage result file
         uses: actions/download-artifact@v3
@@ -40,7 +40,7 @@ jobs:
           path: ./
 
       - name: Setup Python 3.10 in Ubuntu OS
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 

--- a/.github/workflows/run_test_items_via_pytest.yaml
+++ b/.github/workflows/run_test_items_via_pytest.yaml
@@ -103,10 +103,10 @@ jobs:
         test-path: ${{fromJson(inputs.all_test_items_paths)}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -151,10 +151,10 @@ jobs:
         test-path: ${{fromJson(inputs.all_test_items_paths)}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test_gh_reusable_workflow.yaml
+++ b/.github/workflows/test_gh_reusable_workflow.yaml
@@ -48,7 +48,7 @@ jobs:
     env:
       RELEASE_TYPE: ${{ needs.test_build_git-tag_and_create_github-release.outputs.github-action_reusable_workflow_release_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Check it whether get the output of previous one job which has version info or not
         run: bash scripts/ci/check_getting_output.sh

--- a/.github/workflows/test_python_project_ci_multi-tests.yaml
+++ b/.github/workflows/test_python_project_ci_multi-tests.yaml
@@ -154,7 +154,7 @@ jobs:
       RELEASE_TYPE: ${{ needs.build_git-tag_and_create_github-release.outputs.python_release_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check it whether get the output of previous one job which has version info or not
         run: bash scripts/ci/check_getting_output.sh

--- a/.github/workflows/test_python_project_ci_one-test.yaml
+++ b/.github/workflows/test_python_project_ci_one-test.yaml
@@ -123,7 +123,7 @@ jobs:
       RELEASE_TYPE: ${{ needs.build_git-tag_and_create_github-release.outputs.python_release_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check it whether get the output of previous one job which has version info or not
         run: bash scripts/ci/check_getting_output.sh

--- a/.github/workflows/upload_test_cov_report.yaml
+++ b/.github/workflows/upload_test_cov_report.yaml
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download shell script for checking input parameters
         run: curl https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Workflow-Template-Python/develop/scripts/ci/check-input-params.sh --output ./scripts/ci/check-input-params.sh
@@ -96,12 +96,14 @@ jobs:
           echo "Check the parameters of uploading report to Codacy ..."
           bash ./scripts/ci/check-input-params.sh ${{ inputs.upload-to-codacy }} ${{ secrets.codacy_token }}
 
+      # TODO: It's possible be better that open input parameter 'file_path' or 'download name' outside.
       - name: Download code coverage result files which has be handled by different test type process
         uses: actions/download-artifact@v3
         with:
           name: test_coverage_report
           path: ${{ inputs.download_path }}
 
+      # TODO: It's possible be better that open input parameter 'file_path' or 'download name' outside.
       - name: Download code coverage result files which has be handled by different test type process
         uses: actions/download-artifact@v3
         with:
@@ -110,7 +112,7 @@ jobs:
 
       - name: Install Python 3.10
         if: ${{ inputs.upload-to-codecov == true || inputs.upload-to-coveralls == true }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
### _Target_

* Upgrade GitHub Action syntax usage and actions version.


### _Modify Code Scope_

* The configurations in directory _.github/workflow_.


### _Effecting Scope_

* Nothing, it only upgrades GitHub Action setting syntax or actions version. They doesn't effect any features.


### _Description_

* Upgrade the GitHub Action syntax usage about set-output commands.
    * Change to use environment variable _GITHUB_OUTPUT_.
    * Refer: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

* Upgrade the actions which depends on Node.JS version 12 to newer version.
    * Upgrade _actions/checkout_ to version 3.
    * Upgrade _actions/setup-python_ to version 4.
    * Refer: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
